### PR TITLE
Fix build for 4.19.0-041900rc4-generic from ubuntu kernel-ppa

### DIFF
--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -1190,6 +1190,11 @@ unsigned int rtw_classify8021d(struct sk_buff *skb)
 }
 
 
+#if (LINUX_VERSION_CODE>=KERNEL_VERSION(4,19,0))
+static u16 rtw_select_queue(struct net_device *dev, struct sk_buff *skb,
+				struct net_device *sb_dev,
+				select_queue_fallback_t fallback)
+#else
 static u16 rtw_select_queue(struct net_device *dev, struct sk_buff *skb
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0)
 	, void *accel_priv
@@ -1198,6 +1203,7 @@ static u16 rtw_select_queue(struct net_device *dev, struct sk_buff *skb
 	#endif
 #endif
 )
+#endif
 {
 	_adapter	*padapter = rtw_netdev_priv(dev);
 	struct mlme_priv *pmlmepriv = &padapter->mlmepriv;


### PR DESCRIPTION
I'm getting errors building with 4.19 kernel from ubuntu kernel-ppa:

```
  CC [M]  /var/lib/dkms/rtl8821ce/1.0.0/build/os_dep/linux/ioctl_linux.o
/var/lib/dkms/rtl8821ce/1.0.0/build/os_dep/linux/os_intfs.c:1325:22: error: initialization from incompatible pointer type [-Werror=incompatible-pointer-types]
  .ndo_select_queue = rtw_select_queue,
                      ^~~~~~~~~~~~~~~~
```

This change is based on solution reported [here](https://github.com/pvaret/rtl8192cu-fixes/issues/86#issuecomment-220650603)