### PR TITLE
Enable CONFIG_DFS, to support 5Ghz bands only allowed with DFS

### DIFF
--- a/include/hal_ic_cfg.h
+++ b/include/hal_ic_cfg.h
@@ -234,6 +234,7 @@
 #ifdef CONFIG_RTL8821C
 	#undef RTL8821C_SUPPORT
 	#define RTL8821C_SUPPORT				1
+	#define CONFIG_DFS	/* Enable 5G band 2&3 channel */
 	#ifndef CONFIG_FW_C2H_PKT
 		#define CONFIG_FW_C2H_PKT
 	#endif


### PR DESCRIPTION
Fixes issue #34

DFS (as client, not as AP) is supported by the Windows driver, and it seems to be implemented in this driver too (i.e it notifies the upper cfg80211 layer that "Initiate Radiation" isn't allowed on these channels, and handles the frequency switch announcements sent by the AP), it was just disabled.

With this I'm able to connect to routers on 5Ghz channels up to 140.

If you wonder what DFS is:

> 5 GHz
> The 802.11 standard defines 23 20MHz wide channels in the 5 GHz spectrum. Each channel is spaced 20MHz apart and separated into three Unlicensed National Information Infrastructure (UNII) bands. Wireless devices specified as 802.11a/n/ac are capable of operating within these bands. In the United States, UNII-1 (5.150 to 5.250 GHz) containing channels 36, 40, 44, and 48 and UNII-3 (5.725-5.825) containing channels 149, 153, 157, 161 are permitted. UNII-2 (5.250-5.350 GHz and 5.470-5.725 GHz) which contains channels 52, 56, 60, 64, 100, 104, 108, 112, 116, 120, 124, 128, 132, 136, and 140 are permitted in the United States, but shared with radar systems. Therefore, APs operating on UNII-2 channels are required to use Dynamic Frequency Selection (DFS) to avoid interfering with radar signals. If an AP detects a radar signal, it must immediately stop using that channel and randomly pick a new channel. In the United States, even without the use of the UNII-2 band, 5 GHz is well suited for high density deployments due to its greater number of non-overlaping channels.

(I haven't tested the new version of the driver mentioned in #26 though, but from a quick look at its code DFS isn't enabled either.)