### PR TITLE
support pre-5.0 access_ok() API

### DIFF
--- a/os_dep/linux/rtw_android.c
+++ b/os_dep/linux/rtw_android.c
@@ -662,7 +662,11 @@ int rtw_android_priv_cmd(struct net_device *net, struct ifreq *ifr, int cmd)
 		goto exit;
 	}
 
+#if (LINUX_KERNEL_VERSION >= KERNEL_VERSION(5,0,0))
 	if (!access_ok(priv_cmd.buf, priv_cmd.total_len)) {
+#else
+	if (!access_ok(VERIFY_READ, priv_cmd.buf, priv_cmd.total_len)) {
+#endif
 		RTW_INFO("%s: failed to access memory\n", __FUNCTION__);
 		ret = -EFAULT;
 		goto exit;


### PR DESCRIPTION
Pass the mandatory type parameter to `access_ok()` on pre-5.0 kernels,
in this case `VERIFY_READ` for reading memory.

Signed-off-by: Rafael Kitover <rkitover@gmail.com>