### PR TITLE
Disable Debug in production

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ CONFIG_RTW_REPEATER_SON = n
 CONFIG_RTW_WIFI_HAL = n
 CONFIG_ICMP_VOQ = n
 ########################## Debug ###########################
-CONFIG_RTW_DEBUG = y
+CONFIG_RTW_DEBUG = n
 # default log level is _DRV_INFO_ = 4,
 # please refer to "How_to_set_driver_debug_log_level.doc" to set the available level.
 CONFIG_RTW_LOG_LEVEL = 4

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ CONFIG_ICMP_VOQ = n
 CONFIG_RTW_DEBUG = y
 # default log level is _DRV_INFO_ = 4,
 # please refer to "How_to_set_driver_debug_log_level.doc" to set the available level.
-CONFIG_RTW_LOG_LEVEL = 6
+CONFIG_RTW_LOG_LEVEL = 4
 ######################## Wake On Lan ##########################
 CONFIG_WOWLAN = n
 #bit2: deauth, bit1: unicast, bit0: magic pkt.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ Then run the installation script:
 sudo ./dkms-remove.sh
 ```
 
+## Reporting issuess
+When reporting issues, please make sure that debugging is enabled. To enable debugging either set `MAKEFLAGS="CONFIG_RTW_DEBUG = y"` before compilation or edit Makefile:
+```
+CONFIG_RTW_DEBUG = y
+```
+This will enable verbose debug logging, helpful to developers.
+
 ## Possible issues
 
 ### PCIe Activate State Power Management


### PR DESCRIPTION
Debug logging is filling up logs with unnecessary information. Since a lot of people seem to be using this driver in production, I'd rather have this be disabled. Developers and people reporting issues can Recompile with the appropriate flag set.

This resolves #78 and #73 