### PR TITLE
 fallthrough is now a reserved keyword, use __fallthrough__

### DIFF
--- a/core/rtw_mlme_ext.c
+++ b/core/rtw_mlme_ext.c
@@ -258,7 +258,7 @@ void rtw_txpwr_init_regd(struct rf_ctl_t *rfctl)
 		);
 		if (rfctl->regd_name)
 			break;
-		__attribute__ ((fallthrough));
+		__attribute__((__fallthrough__));
 	default:
 		rfctl->regd_name = regd_str(TXPWR_LMT_WW);
 		RTW_PRINT("assign %s for default case\n", regd_str(TXPWR_LMT_WW));
@@ -1328,7 +1328,7 @@ void mgt_dispatcher(_adapter *padapter, union recv_frame *precv_frame)
 			ptable->func = &OnAuth;
 		else
 			ptable->func = &OnAuthClient;
-		__attribute__ ((fallthrough));
+		__attribute__((__fallthrough__));
 	case WIFI_ASSOCREQ:
 	case WIFI_REASSOCREQ:
 		_mgt_dispatcher(padapter, ptable, precv_frame);

--- a/hal/hal_halmac.c
+++ b/hal/hal_halmac.c
@@ -2900,7 +2900,7 @@ static int _send_general_info(struct dvobj_priv *d)
 	case HALMAC_RET_NO_DLFW:
 		RTW_WARN("%s: halmac_send_general_info() fail because fw not dl!\n",
 			 __FUNCTION__);
-		__attribute__ ((fallthrough));
+		__attribute__((__fallthrough__));
 	default:
 		return -1;
 	}

--- a/hal/hal_intf.c
+++ b/hal/hal_intf.c
@@ -1070,7 +1070,7 @@ s32 c2h_handler(_adapter *adapter, u8 id, u8 seq, u8 plen, u8 *payload)
 #endif
 	case C2H_EXTEND:
 		sub_id = payload[0];
-		__attribute__ ((fallthrough));
+		__attribute__((__fallthrough__));
 	default:
 		if (phydm_c2H_content_parsing(adapter_to_phydm(adapter), id, plen, payload) != TRUE)
 			ret = _FAIL;

--- a/hal/halmac/halmac_88xx/halmac_mimo_88xx.c
+++ b/hal/halmac/halmac_88xx/halmac_mimo_88xx.c
@@ -62,10 +62,10 @@ cfg_txbf_88xx(struct halmac_adapter *adapter, u8 userid, enum halmac_bw bw,
 		switch (bw) {
 		case HALMAC_BW_80:
 			tmp42c |= BIT_R_TXBF0_80M;
-			__attribute__ ((fallthrough));
+			__attribute__((__fallthrough__));
 		case HALMAC_BW_40:
 			tmp42c |= BIT_R_TXBF0_40M;
-			__attribute__ ((fallthrough));
+			__attribute__((__fallthrough__));
 		case HALMAC_BW_20:
 			tmp42c |= BIT_R_TXBF0_20M;
 			break;

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -2350,7 +2350,7 @@ static int cfg80211_rtw_change_iface(struct wiphy *wiphy,
 	#if defined(CONFIG_P2P) && ((LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37)) || defined(COMPAT_KERNEL_RELEASE))
 	case NL80211_IFTYPE_P2P_CLIENT:
 		is_p2p = _TRUE;
-		__attribute__ ((fallthrough));
+		__attribute__((__fallthrough__));
 	#endif
 	case NL80211_IFTYPE_STATION:
 		networkType = Ndis802_11Infrastructure;
@@ -2375,7 +2375,7 @@ static int cfg80211_rtw_change_iface(struct wiphy *wiphy,
 	#if defined(CONFIG_P2P) && ((LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37)) || defined(COMPAT_KERNEL_RELEASE))
 	case NL80211_IFTYPE_P2P_GO:
 		is_p2p = _TRUE;
-		__attribute__ ((fallthrough));
+		__attribute__((__fallthrough__));
 	#endif
 	case NL80211_IFTYPE_AP:
 		networkType = Ndis802_11APMode;


### PR DESCRIPTION
torvalds/linux@294f69e662