### PR TITLE
Revert "Support in-tree compilation"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,7 @@ ifeq ($(GCC_VER_49),1)
 EXTRA_CFLAGS += -Wno-date-time	# Fix compile error && warning on gcc 4.9 and later
 endif
 
-ifneq (,$(findstring /usr/lib/dkms,$(PATH)))
-    export TopDIR ?= $(shell pwd)
-else
-    export TopDIR ?= $(srctree)/$(src)
-endif
+export TopDIR ?= $(shell pwd)
 
 EXTRA_CFLAGS += -I$(TopDIR)/include
 


### PR DESCRIPTION
This reverts commit bde9b3208a509588d64816895b882b91358ac8bc.

On Ubuntu, I could not "make" again inside of the master branch