### PR TITLE
Remove extra bracket on srctree conditional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ ifeq ($(GCC_VER_49),1)
 EXTRA_CFLAGS += -Wno-date-time	# Fix compile error && warning on gcc 4.9 and later
 endif
 
-ifeq (,$(srctree)))
+ifeq (,$(srctree))
     # make processing
     export TopDIR ?= $(shell pwd)
 else


### PR DESCRIPTION
Stops make complaining on in-tree compile:
drivers/net/wireless/rtl8821ce/Makefile:24: extraneous text after 'ifeq' directive