### PR TITLE
Don't recommend an AUR helper for Arch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Realtek RTL8821CE Driver
 
 ## Intent
-This repository hosts the code for the [ArchLinux AUR Package](https://aur.archlinux.org/packages/rtl8821ce-dkms-git/). It's targetting Linux > 4.14 and is being developed for ArchLinux and Ubuntu 18.10. No support will be provided for other Linux distributions or Linux Kernel versions outside of that range.
+This repository hosts the code for the [Arch Linux AUR Package](https://aur.archlinux.org/packages/rtl8821ce-dkms-git/). It's targeting Linux > 4.14 and is being developed for Arch Linux and Ubuntu 18.10. No support will be provided for other Linux distributions or Linux Kernel versions outside of that range.
 
 ## Disclaimer
 The maintainers of this repository are not Realtek employees and are maintaining this repository for their own usage. Further feature development (such as proper power saving, etc.) will not be pursued here, but will be gladly integrated if newer driver sources are provided by Realtek. Use at your own risk.
@@ -20,15 +20,13 @@ sudo m-a prepare
 ```
 
 ### Arch Linux
-Generally speaking, Arch Linux already comes with a compiler toolchain installed. If you have a weird installation, just make sure you have the `base-devel` package group installed before you proceed.
+Make sure you have the `base-devel` package group installed before you proceed for the necessary compilation tools.
 
 #### Installing from AUR
-```
-yaourt -Sy aur/rtl8821ce-dkms-git
-```
-And that's it.
 
-#### Depencies for manual installation on Arch Linux
+Install [rtl8821ce-dkms-git](https://aur.archlinux.org/packages/rtl8821ce-dkms-git/) from the [AUR](https://wiki.archlinux.org/index.php/Arch_User_Repository).
+
+#### Dependencies for manual installation on Arch Linux
 ```
 sudo pacman -Syu linux-headers dkms
 ```


### PR DESCRIPTION
Do not recommend an AUR helper, as they go in and out of support all the time(not to mention that yaourt specifically is insecure and unsupported), rather link to the wiki page of AUR which contains manual build instructions.

Base Arch Linux install does not come with a compiler toolchain.

Also changed instances of "ArchLinux" into "Arch Linux".

Fixed typos.