### PR TITLE
Add a simple check to prevent kernel panics from nullptr dereferences

### DIFF
--- a/core/rtw_mlme.c
+++ b/core/rtw_mlme.c
@@ -4275,6 +4275,14 @@ static int rtw_rsn_sync_pmkid(_adapter *adapter, u8 *ie, uint ie_len, int i_ent)
 	if (i_ent >= 0) {
 		RTW_INFO(FUNC_ADPT_FMT" append PMKID:"KEY_FMT"\n"
 			, FUNC_ADPT_ARG(adapter), KEY_ARG(sec->PMKIDList[i_ent].PMKID));
+        if (!info.pmkid_list) {
+            /* prevent nullptr dereference when trying to insert a PMKID into 
+             * a frame that did not previously contain one. In order to be minimally
+             * invasive, we just discard requests like these, which might impact
+             * the ability to connect to certain access points, but will at least
+             * prevent the kernel panics */
+            return 0;
+        }
 
 		info.pmkid_cnt = 1; /* update new pmkid_cnt */
 		_rtw_memcpy(info.pmkid_list, sec->PMKIDList[i_ent].PMKID, 16);


### PR DESCRIPTION
The kernel panics mentioned in #77 occur when the driver is trying to construct an RSN Information Element to send back to the access point, which is done by restructuring the existing IE that has been received previously. If the driver receives a PKMID though ioctl, which is supposed to be included in the IE, but the original IE did not contain a PMKID field, a null pointer dereference occurs.

This can be fixed in various ways:
- We can check for a null pointer beforehand and abort in this case to prevent the panic.
- We can write into the position where the PMKID is supposed to be. (According to what I gathered from the code, this can not cause any memory corruption, since the IE struct is always allocated for the maximum length, which is not reached if it does not contain a PMKID).
- We can allocate an entirely new IE (which would prevent memory corruption, but potentially cause many more problems (in particular, it might not be thread-safe), as I don't know where else the pointer to this IE is used.

Because this is a kernel module with code from a different source that I don't feel to comfortable messing around with, I chose the first option as the minimally invasive one. This has prevented any further panics on the machine I was working with, although there are signs that it does impact the ability to connect to certain access points (that is, networks using RSN) at certain times (when the panics or the connection failures occur follows no pattern that I understood so far).

Since you already declared that you couldn't help with this problem I was not sure if you would want to actually merge this, but I still opted to pull request this fix just so that the relevant code is out there for those who are experiencing the same problems.

Fixes #77.