### PR TITLE
Create ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: install dependencies
+      run: sudo apt install bc module-assistant build-essential dkms
+    - name: prepare build
+      run: sudo m-a prepare
+    - name: build and install dkms
+      run: sudo ./dkms-install.sh


### PR DESCRIPTION
This is a simple github actions configuration for Continuous integration.
On every commit pushed to origin the kernel module will be built to make testing easier and assure every commit and pull request at least compiles.