### PR TITLE
Add constants to allow 22MB and 33MB data rate

### DIFF
--- a/core/rtw_wlan_util.c
+++ b/core/rtw_wlan_util.c
@@ -2290,6 +2290,8 @@ u8 support_rate_ranges[] = {
 	IEEE80211_OFDM_RATE_36MB,
 	IEEE80211_OFDM_RATE_48MB,
 	IEEE80211_OFDM_RATE_54MB,
+	0x2c, // 22MB
+	0x42, // 33MB
 };
 
 inline bool match_ranges(u16 EID, u32 value)


### PR DESCRIPTION
The update of the driver to the version 'Realtek v5.5.2' introduce
a check of the DR broadcasted in the WLAN_EID_SUPP_RATES IE.
As a conseconsed AP with 22MB or 33MB Data Rate are filtered out.
The check has been added in to function collect_bss_info of rtw_mlne_ext.c
and performed in the function rtw_validate_value of rtw_wlan_util.c

Adding these constants will allow to make the AP available again.
Even if I did not observe any issue, I don't known if the driver is
able to support such data rate.

Anyway this patch permits to connect again on "Freebox" AP, the modem
provided by French ISP "Free". Issue #64