### PR TITLE
Fixed kernel 5.10.0 problems mentioned  in 9fd63b7fe849f5fa8019c897d1642ce4f34bf3f7

### DIFF
--- a/core/rtw_btcoex.c
+++ b/core/rtw_btcoex.c
@@ -1475,9 +1475,12 @@ u8 rtw_btcoex_sendmsgbysocket(_adapter *padapter, u8 *msg, u8 msg_size, bool for
 	udpmsg.msg_controllen = 0;
 	udpmsg.msg_flags	= MSG_DONTWAIT | MSG_NOSIGNAL;
 
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))
+#if (LINUX_VERSION_CODE <= KERNEL_VERSION(5, 10, 0))
 	oldfs = get_fs();
 	set_fs(KERNEL_DS);
+#else
+	oldfs = (current_thread_info()->addr_limit);
+	current_thread_info()->addr_limit = (MAKE_MM_SEG(-1UL));
 #endif
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0))
@@ -1487,6 +1490,8 @@ u8 rtw_btcoex_sendmsgbysocket(_adapter *padapter, u8 *msg, u8 msg_size, bool for
 #endif
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))
 	set_fs(oldfs);
+#else
+	current_thread_info()->addr_limit = (oldfs);
 #endif
 	if (error < 0) {
 		RTW_INFO("Error when sendimg msg, error:%d\n", error);

--- a/core/rtw_btcoex.c
+++ b/core/rtw_btcoex.c
@@ -17,6 +17,12 @@
 #ifdef CONFIG_BT_COEXIST
 #include <hal_btcoex.h>
 
+#ifdef PLATFORM_LINUX
+	#ifndef KERNEL_DS
+		#define KERNEL_DS   MAKE_MM_SEG(-1UL)   // <----- 0xffffffffffffffff
+	#endif
+#endif
+
 void rtw_btcoex_Initialize(PADAPTER padapter)
 {
 	hal_btcoex_Initialize(padapter);

--- a/core/rtw_btcoex.c
+++ b/core/rtw_btcoex.c
@@ -1475,12 +1475,11 @@ u8 rtw_btcoex_sendmsgbysocket(_adapter *padapter, u8 *msg, u8 msg_size, bool for
 	udpmsg.msg_controllen = 0;
 	udpmsg.msg_flags	= MSG_DONTWAIT | MSG_NOSIGNAL;
 
-#if (LINUX_VERSION_CODE <= KERNEL_VERSION(5, 10, 0))
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))
 	oldfs = get_fs();
 	set_fs(KERNEL_DS);
 #else
-	oldfs = (current_thread_info()->addr_limit);
-	current_thread_info()->addr_limit = (MAKE_MM_SEG(-1UL));
+	oldfs = force_uaccess_begin();
 #endif
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0))
@@ -1491,7 +1490,7 @@ u8 rtw_btcoex_sendmsgbysocket(_adapter *padapter, u8 *msg, u8 msg_size, bool for
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))
 	set_fs(oldfs);
 #else
-	current_thread_info()->addr_limit = (oldfs);
+	force_uaccess_end(oldfs);
 #endif
 	if (error < 0) {
 		RTW_INFO("Error when sendimg msg, error:%d\n", error);

--- a/core/rtw_ieee80211.c
+++ b/core/rtw_ieee80211.c
@@ -19,6 +19,11 @@
 #endif
 #include <drv_types.h>
 
+#ifdef PLATFORM_LINUX
+	#ifndef KERNEL_DS
+		#define KERNEL_DS   MAKE_MM_SEG(-1UL)   // <----- 0xffffffffffffffff
+	#endif
+#endif
 
 u8 RTW_WPA_OUI_TYPE[] = { 0x00, 0x50, 0xf2, 1 };
 u16 RTW_WPA_VERSION = 1;

--- a/core/rtw_wlan_util.c
+++ b/core/rtw_wlan_util.c
@@ -4757,7 +4757,7 @@ int rtw_dev_nlo_info_set(struct pno_nlo_info *nlo_info, pno_ssid_t *ssid,
 		return 0;
 	}
 
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 0, 0))
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))
 	fs = get_fs();
 	set_fs(KERNEL_DS);
 #else

--- a/core/rtw_wlan_util.c
+++ b/core/rtw_wlan_util.c
@@ -4751,12 +4751,11 @@ int rtw_dev_nlo_info_set(struct pno_nlo_info *nlo_info, pno_ssid_t *ssid,
 		return 0;
 	}
 
-#if (LINUX_VERSION_CODE <= KERNEL_VERSION(5, 10, 0))
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 0, 0))
 	fs = get_fs();
 	set_fs(KERNEL_DS);
 #else
-	fs = (current_thread_info()->addr_limit);
-	current_thread_info()->addr_limit = (MAKE_MM_SEG(-1UL));
+	fs = force_uaccess_begin();
 #endif
 
 	source = rtw_zmalloc(2048);
@@ -4767,10 +4766,10 @@ int rtw_dev_nlo_info_set(struct pno_nlo_info *nlo_info, pno_ssid_t *ssid,
 		rtw_mfree(source, 2048);
 	}
 
-#if (LINUX_VERSION_CODE <= KERNEL_VERSION(5, 10, 0))
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))
 	set_fs(fs);
 #else
-	current_thread_info()->addr_limit = (fs);
+	force_uaccess_end(fs);
 #endif
 	filp_close(fp, NULL);
 

--- a/core/rtw_wlan_util.c
+++ b/core/rtw_wlan_util.c
@@ -4754,6 +4754,9 @@ int rtw_dev_nlo_info_set(struct pno_nlo_info *nlo_info, pno_ssid_t *ssid,
 #if (LINUX_VERSION_CODE <= KERNEL_VERSION(5, 10, 0))
 	fs = get_fs();
 	set_fs(KERNEL_DS);
+#else
+	fs = (current_thread_info()->addr_limit);
+	current_thread_info()->addr_limit = (MAKE_MM_SEG(-1UL));
 #endif
 
 	source = rtw_zmalloc(2048);
@@ -4766,6 +4769,8 @@ int rtw_dev_nlo_info_set(struct pno_nlo_info *nlo_info, pno_ssid_t *ssid,
 
 #if (LINUX_VERSION_CODE <= KERNEL_VERSION(5, 10, 0))
 	set_fs(fs);
+#else
+	current_thread_info()->addr_limit = (fs);
 #endif
 	filp_close(fp, NULL);
 

--- a/core/rtw_wlan_util.c
+++ b/core/rtw_wlan_util.c
@@ -26,6 +26,12 @@
 	#define IPv6_PROTOCOL_OFFSET	20
 #endif
 
+#ifdef PLATFORM_LINUX
+	#ifndef KERNEL_DS
+		#define KERNEL_DS   MAKE_MM_SEG(-1UL)   // <----- 0xffffffffffffffff
+	#endif
+#endif
+
 unsigned char ARTHEROS_OUI1[] = {0x00, 0x03, 0x7f};
 unsigned char ARTHEROS_OUI2[] = {0x00, 0x13, 0x74};
 

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -4012,8 +4012,7 @@ static int route_dump(u32 *gw_addr , int *gw_index)
 	oldfs = get_fs();
 	set_fs(KERNEL_DS);
 #else
-	oldfs = (current_thread_info()->addr_limit);
-	current_thread_info()->addr_limit = ((mm_segment_t) { (-1UL) });
+	oldfs = force_uaccess_begin();
 #endif
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0))
 	err = sock_sendmsg(sock, &msg);
@@ -4023,7 +4022,7 @@ static int route_dump(u32 *gw_addr , int *gw_index)
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))
 	set_fs(oldfs);
 #else
-	current_thread_info()->addr_limit = (oldfs);
+	force_uaccess_end(oldfs);
 #endif
 
 	if (err < 0)
@@ -4053,8 +4052,7 @@ restart:
 		oldfs = get_fs();
 		set_fs(KERNEL_DS);
 #else
-	oldfs = (current_thread_info()->addr_limit);
-	current_thread_info()->addr_limit = ((mm_segment_t) { (-1UL) });
+		oldfs = force_uaccess_begin();
 #endif
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 7, 0))
 		err = sock_recvmsg(sock, &msg, MSG_DONTWAIT);
@@ -4064,7 +4062,7 @@ restart:
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))
 		set_fs(oldfs);
 #else
-		current_thread_info()->addr_limit = (oldfs);
+		force_uaccess_end(oldfs);
 
 #endif
 
@@ -4141,8 +4139,7 @@ done:
 		oldfs = get_fs();
 		set_fs(KERNEL_DS);
 #else
-		oldfs = (current_thread_info()->addr_limit);
-		current_thread_info()->addr_limit = ((mm_segment_t) { (-1UL) });
+		oldfs = force_uaccess_begin();
 #endif
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0))
 		err = sock_sendmsg(sock, &msg);
@@ -4152,8 +4149,7 @@ done:
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))
 		set_fs(oldfs);
 #else
-		current_thread_info()->addr_limit = (oldfs);
-
+		force_uaccess_end(oldfs)
 #endif
 
 		if (err > 0)

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -23,6 +23,11 @@
 
 #endif
 
+#ifdef PLATFORM_LINUX
+	#ifndef KERNEL_DS
+		#define KERNEL_DS   MAKE_MM_SEG(-1UL)   // <----- 0xffffffffffffffff
+	#endif
+#endif
 
 MODULE_LICENSE("GPL");
 MODULE_DESCRIPTION("Realtek Wireless Lan Driver");

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -4011,6 +4011,9 @@ static int route_dump(u32 *gw_addr , int *gw_index)
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))
 	oldfs = get_fs();
 	set_fs(KERNEL_DS);
+#else
+	oldfs = (current_thread_info()->addr_limit);
+	current_thread_info()->addr_limit = ((mm_segment_t) { (-1UL) });
 #endif
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0))
 	err = sock_sendmsg(sock, &msg);
@@ -4019,6 +4022,8 @@ static int route_dump(u32 *gw_addr , int *gw_index)
 #endif
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))
 	set_fs(oldfs);
+#else
+	current_thread_info()->addr_limit = (oldfs);
 #endif
 
 	if (err < 0)
@@ -4047,6 +4052,9 @@ restart:
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))
 		oldfs = get_fs();
 		set_fs(KERNEL_DS);
+#else
+	oldfs = (current_thread_info()->addr_limit);
+	current_thread_info()->addr_limit = ((mm_segment_t) { (-1UL) });
 #endif
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 7, 0))
 		err = sock_recvmsg(sock, &msg, MSG_DONTWAIT);
@@ -4055,6 +4063,9 @@ restart:
 #endif
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))
 		set_fs(oldfs);
+#else
+		current_thread_info()->addr_limit = (oldfs);
+
 #endif
 
 		if (err < 0)
@@ -4129,6 +4140,9 @@ done:
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))
 		oldfs = get_fs();
 		set_fs(KERNEL_DS);
+#else
+		oldfs = (current_thread_info()->addr_limit);
+		current_thread_info()->addr_limit = ((mm_segment_t) { (-1UL) });
 #endif
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0))
 		err = sock_sendmsg(sock, &msg);
@@ -4137,6 +4151,9 @@ done:
 #endif
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))
 		set_fs(oldfs);
+#else
+		current_thread_info()->addr_limit = (oldfs);
+
 #endif
 
 		if (err > 0)

--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -28,7 +28,9 @@ atomic_t _malloc_size = ATOMIC_INIT(0);
 #endif /* DBG_MEMORY_LEAK */
 
 
+
 #if defined(PLATFORM_LINUX)
+
 /*
 * Translate the OS dependent @param error_code to OS independent RTW_STATUS_CODE
 * @return: one of RTW_STATUS_CODE
@@ -2204,8 +2206,7 @@ static int isFileReadable(const char *path, u32 *sz)
 		oldfs = get_fs();
 		set_fs(KERNEL_DS);
 	#else
-		oldfs = (current_thread_info()->addr_limit);
-		current_thread_info()->addr_limit = ((mm_segment_t) { (-1UL) });
+		oldfs = force_uaccess_begin();;
 	#endif
 
 		if (1 != readFile(fp, &buf, 1))
@@ -2222,8 +2223,7 @@ static int isFileReadable(const char *path, u32 *sz)
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))
 		set_fs(oldfs);
 #else
-		current_thread_info()->addr_limit = (oldfs);
-
+        force_uaccess_end(oldfs);
 #endif
 		filp_close(fp, NULL);
 	}
@@ -2252,14 +2252,13 @@ static int retriveFromFile(const char *path, u8 *buf, u32 sz)
 			oldfs = get_fs();
 			set_fs(KERNEL_DS);
 		#else
-			oldfs = (current_thread_info()->addr_limit);
-				current_thread_info()->addr_limit = ((mm_segment_t) { (-1UL) });
+			oldfs = force_uaccess_begin();
 		#endif
 			ret = readFile(fp, buf, sz);
 		#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))
 			set_fs(oldfs);
 		#else
-			current_thread_info()->addr_limit = (oldfs);
+      		force_uaccess_end(oldfs);
 		#endif
 			closeFile(fp);
 
@@ -2296,14 +2295,13 @@ static int storeToFile(const char *path, u8 *buf, u32 sz)
 			oldfs = get_fs();
 			set_fs(KERNEL_DS);
 		#else
-			oldfs = (current_thread_info()->addr_limit);
-			current_thread_info()->addr_limit = ((mm_segment_t) { (-1UL) });
+	   		oldfs = force_uaccess_begin();
 		#endif
 			ret = writeFile(fp, buf, sz);
 		#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))
 			set_fs(oldfs);
 		#else
-			current_thread_info()->addr_limit = (oldfs);
+			force_uaccess_end(oldfs);
 		#endif
 			closeFile(fp);
 

--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -2203,6 +2203,9 @@ static int isFileReadable(const char *path, u32 *sz)
 	#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))
 		oldfs = get_fs();
 		set_fs(KERNEL_DS);
+	#else
+		oldfs = (current_thread_info()->addr_limit);
+		current_thread_info()->addr_limit = ((mm_segment_t) { (-1UL) });
 	#endif
 
 		if (1 != readFile(fp, &buf, 1))
@@ -2218,6 +2221,9 @@ static int isFileReadable(const char *path, u32 *sz)
 
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))
 		set_fs(oldfs);
+#else
+		current_thread_info()->addr_limit = (oldfs);
+
 #endif
 		filp_close(fp, NULL);
 	}
@@ -2245,10 +2251,15 @@ static int retriveFromFile(const char *path, u8 *buf, u32 sz)
 		#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))
 			oldfs = get_fs();
 			set_fs(KERNEL_DS);
+		#else
+			oldfs = (current_thread_info()->addr_limit);
+				current_thread_info()->addr_limit = ((mm_segment_t) { (-1UL) });
 		#endif
 			ret = readFile(fp, buf, sz);
 		#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))
 			set_fs(oldfs);
+		#else
+			current_thread_info()->addr_limit = (oldfs);
 		#endif
 			closeFile(fp);
 
@@ -2284,10 +2295,15 @@ static int storeToFile(const char *path, u8 *buf, u32 sz)
 		#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))
 			oldfs = get_fs();
 			set_fs(KERNEL_DS);
+		#else
+			oldfs = (current_thread_info()->addr_limit);
+			current_thread_info()->addr_limit = ((mm_segment_t) { (-1UL) });
 		#endif
 			ret = writeFile(fp, buf, sz);
 		#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))
 			set_fs(oldfs);
+		#else
+			current_thread_info()->addr_limit = (oldfs);
 		#endif
 			closeFile(fp);
 

--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -24,6 +24,9 @@
 #ifdef PLATFORM_LINUX
 atomic_t _malloc_cnt = ATOMIC_INIT(0);
 atomic_t _malloc_size = ATOMIC_INIT(0);
+#ifndef KERNEL_DS
+#define KERNEL_DS   MAKE_MM_SEG(-1UL)   // <----- 0xffffffffffffffff
+#endif
 #endif
 #endif /* DBG_MEMORY_LEAK */
 


### PR DESCRIPTION
There was runtime problems caused due to lack of get_fs function. I fixed it.