### PR TITLE
Add PCI ID 10ec:b821 (TP-Link AC600 Archer T2E)

### DIFF
--- a/os_dep/linux/pci_intf.c
+++ b/os_dep/linux/pci_intf.c
@@ -88,6 +88,7 @@ struct pci_device_id rtw_pci_id_tbl[] = {
 	{PCI_DEVICE(PCI_VENDER_ID_REALTEK, 0xB822), .driver_data = RTL8822B},
 #endif
 #ifdef CONFIG_RTL8821C
+	{PCI_DEVICE(PCI_VENDER_ID_REALTEK, 0xB821), .driver_data = RTL8821C},
 	{PCI_DEVICE(PCI_VENDER_ID_REALTEK, 0xC821), .driver_data = RTL8821C},
 	{PCI_DEVICE(PCI_VENDER_ID_REALTEK, 0xC82A), .driver_data = RTL8821C},
 	{PCI_DEVICE(PCI_VENDER_ID_REALTEK, 0xC82B), .driver_data = RTL8821C},


### PR DESCRIPTION
This ID can be found in the Windows driver and in rtw88.

Fixes https://github.com/tomaspinho/rtl8821ce/issues/273.