### PR TITLE
Fix incorrect kernel option and add grubby equivalent.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,10 @@ Your distribution may come with PCIe Active State Power Management enabled by de
 ```
 sudo $EDITOR /etc/default/grub
 ```
-Add pci=noaer at the end of GRUB_CMDLINE_LINUX_DEFAULT. Line should look like this:
+Add pcie_aspm=off at the end of GRUB_CMDLINE_LINUX_DEFAULT. Line should look like this:
 
 ```
-GRUB_CMDLINE_LINUX_DEFAULT="quiet splash pci=noaer"
+GRUB_CMDLINE_LINUX_DEFAULT="quiet splash pcie_aspm=off"
 ```
 
 Then update your GRUB configuration:
@@ -107,6 +107,10 @@ Then update your GRUB configuration:
 sudo update-grub
 ```
 
+On systems that doesn't have `update-grub` but have `grubby` like Fedora, you can directly execute instead:
+```
+sudo grubby --update-kernel=ALL --args=pcie_aspm=off
+```
 Reboot.
 
 ### Lenovo Yoga laptops

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ This will enable verbose debug logging, helpful to developers.
 
 ## Possible issues
 
-### PCIe Activate State Power Management
+### PCIe Active State Power Management
 Your distribution may come with PCIe Active State Power Management enabled by default. That may conflict with this driver. To disable:
 
 ```


### PR DESCRIPTION
- Add the correct kernel option to disable PCIe ASPM.
- Add the grubby equivalent for managing kernel options.