### PR TITLE
Fix strlen buffer overrun

### DIFF
--- a/core/rtw_rf.c
+++ b/core/rtw_rf.c
@@ -1225,7 +1225,7 @@ s8 rtw_rf_get_kfree_tx_gain_offset(_adapter *padapter, u8 path, u8 ch)
 		kfree_offset = kfree_data->bb_gain[bb_gain_sel][path];
 		if (IS_HARDWARE_TYPE_8723D(padapter))
 			RTW_INFO("%s path:%s, ch:%u, bb_gain_sel:%d, kfree_offset:%d\n"
-				, __func__, (path == 0)?"S1":"S0",
+				, __func__, (path == 0)?"S1":"S0", 
 				ch, bb_gain_sel, kfree_offset);
 		else
 			RTW_INFO("%s path:%u, ch:%u, bb_gain_sel:%d, kfree_offset:%d\n"
@@ -1256,7 +1256,7 @@ void rtw_rf_set_tx_gain_offset(_adapter *adapter, u8 path, s8 offset)
 		target_path = path;
 		RTW_INFO("kfree gain_offset 0x55:0x%x ", rtw_hal_read_rfreg(adapter, target_path, 0x55, 0xffffffff));
 	}
-
+	
 	switch (rtw_get_chip_type(adapter)) {
 #ifdef CONFIG_RTL8723D
 	case RTL8723D:
@@ -1311,7 +1311,7 @@ void rtw_rf_set_tx_gain_offset(_adapter *adapter, u8 path, s8 offset)
 		rtw_warn_on(1);
 		break;
 	}
-
+	
 	if (IS_HARDWARE_TYPE_8723D(adapter)) {
 		if (path == PPG_8723D_S1)
 			val32 = rtw_hal_read_rfreg(adapter, target_path, 0x55, 0xffffffff);

--- a/core/rtw_rf.c
+++ b/core/rtw_rf.c
@@ -1050,12 +1050,8 @@ void rtw_txpwr_lmt_add_with_nlen(struct rf_ctl_t *rfctl, const char *regd_name, 
 		ent = LIST_CONTAINOR(cur, struct txpwr_lmt_ent, list);
 		cur = get_next(cur);
 
-		#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 1))
-		if (_rtw_memcmp(ent->regd_name, regd_name, nlen) == _TRUE)
-		#else
 		if (strlen(ent->regd_name) == nlen
 			&& _rtw_memcmp(ent->regd_name, regd_name, nlen) == _TRUE)
-		#endif
 			goto chk_lmt_val;
 	}
 
@@ -1229,7 +1225,7 @@ s8 rtw_rf_get_kfree_tx_gain_offset(_adapter *padapter, u8 path, u8 ch)
 		kfree_offset = kfree_data->bb_gain[bb_gain_sel][path];
 		if (IS_HARDWARE_TYPE_8723D(padapter))
 			RTW_INFO("%s path:%s, ch:%u, bb_gain_sel:%d, kfree_offset:%d\n"
-				, __func__, (path == 0)?"S1":"S0", 
+				, __func__, (path == 0)?"S1":"S0",
 				ch, bb_gain_sel, kfree_offset);
 		else
 			RTW_INFO("%s path:%u, ch:%u, bb_gain_sel:%d, kfree_offset:%d\n"
@@ -1260,7 +1256,7 @@ void rtw_rf_set_tx_gain_offset(_adapter *adapter, u8 path, s8 offset)
 		target_path = path;
 		RTW_INFO("kfree gain_offset 0x55:0x%x ", rtw_hal_read_rfreg(adapter, target_path, 0x55, 0xffffffff));
 	}
-	
+
 	switch (rtw_get_chip_type(adapter)) {
 #ifdef CONFIG_RTL8723D
 	case RTL8723D:
@@ -1315,7 +1311,7 @@ void rtw_rf_set_tx_gain_offset(_adapter *adapter, u8 path, s8 offset)
 		rtw_warn_on(1);
 		break;
 	}
-	
+
 	if (IS_HARDWARE_TYPE_8723D(adapter)) {
 		if (path == PPG_8723D_S1)
 			val32 = rtw_hal_read_rfreg(adapter, target_path, 0x55, 0xffffffff);

--- a/include/hal_data.h
+++ b/include/hal_data.h
@@ -332,7 +332,12 @@ struct txpwr_lmt_ent {
 		[MAX_TX_COUNT];
 #endif
 
-	char regd_name[0];
+    #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 1))
+	char regd_name[];
+    #else
+    char regd_name[0];
+    #endif
+
 };
 #endif /* CONFIG_TXPWR_LIMIT */
 

--- a/include/hal_data.h
+++ b/include/hal_data.h
@@ -332,12 +332,11 @@ struct txpwr_lmt_ent {
 		[MAX_TX_COUNT];
 #endif
 
-    #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 1))
+	#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 18, 0))
 	char regd_name[];
-    #else
-    char regd_name[0];
-    #endif
-
+	#else
+	char regd_name[0];
+	#endif
 };
 #endif /* CONFIG_TXPWR_LIMIT */
 

--- a/include/rtw_rf.h
+++ b/include/rtw_rf.h
@@ -173,7 +173,7 @@ struct regd_exc_ent {
 	_list list;
 	char country[2];
 	u8 domain;
-	#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 1))
+	#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 18, 0))
 	char regd_name[];
 	#else
 	char regd_name[0];

--- a/include/rtw_rf.h
+++ b/include/rtw_rf.h
@@ -173,7 +173,12 @@ struct regd_exc_ent {
 	_list list;
 	char country[2];
 	u8 domain;
-	char regd_name[0];
+
+    #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 1))
+	char regd_name[];
+    #else
+    char regd_name[0];
+    #endif
 };
 
 void dump_regd_exc_list(void *sel, struct rf_ctl_t *rfctl);

--- a/include/rtw_rf.h
+++ b/include/rtw_rf.h
@@ -173,12 +173,11 @@ struct regd_exc_ent {
 	_list list;
 	char country[2];
 	u8 domain;
-
-    #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 1))
+	#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 1))
 	char regd_name[];
-    #else
-    char regd_name[0];
-    #endif
+	#else
+	char regd_name[0];
+	#endif
 };
 
 void dump_regd_exc_list(void *sel, struct rf_ctl_t *rfctl);


### PR DESCRIPTION
Basically the syntax to declare a flexible array member like this `char* regd_name[0]` has become so obsolete that it's treated as a zero sized string regardless of its contents, therefore `__fortify_stlren` was crashing while trying to read the first byte.

This also reverts #332 as it's not needed anymore.