### PR TITLE
changes for kernel v6.9

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -417,13 +417,13 @@ u8 rtw_cfg80211_ch_switch_notify(_adapter *adapter, u8 ch, u8 bw, u8 offset, u8 
 	if (ret != _SUCCESS)
 		goto exit;
 
- #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 2)
+ #if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 2))
 	cfg80211_ch_switch_notify(adapter->pnetdev, &chdef);
-#elif LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
+ #elif (LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)) || (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 9, 0))
 	cfg80211_ch_switch_notify(adapter->pnetdev, &chdef, 0);
-#else
+ #else
 	cfg80211_ch_switch_notify(adapter->pnetdev, &chdef, 0, 0);
-#endif
+ #endif
 
 #else
 	int freq = rtw_ch2freq(ch);


### PR DESCRIPTION
Hi @tomaspinho , this small change allows driver compilation and operation under kernel v6.9.  Tested on the Linux 6.9-rc1 kernel on amd64 with an rtl8821ce-based Wi-Fi adapter.