### PR TITLE
make ifs more consistent

### DIFF
--- a/include/wifi.h
+++ b/include/wifi.h
@@ -1027,7 +1027,7 @@ typedef enum _HT_CAP_AMPDU_DENSITY {
  * According to IEEE802.11n spec size varies from 8K to 64K (in powers of 2)
  */
 #define IEEE80211_MIN_AMPDU_BUF 0x8
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,19,0)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 19, 0))
 #define IEEE80211_MAX_AMPDU_BUF_HT 0x40
 #define IEEE80211_MAX_AMPDU_BUF 0x100
 #else

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -883,11 +883,12 @@ struct cfg80211_bss *rtw_cfg80211_inform_bss(_adapter *padapter, struct wlan_net
 		}
 	}
 #endif
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 9, 0)
-	cfg80211_put_bss(wiphy, bss);
-#else
-	cfg80211_put_bss(bss);
+	cfg80211_put_bss(
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 9, 0))
+		wiphy,
 #endif
+		bss
+	);
 
 exit:
 	if (pbuf)
@@ -917,18 +918,21 @@ int rtw_cfg80211_check_bss(_adapter *padapter)
 	bss = cfg80211_get_bss(padapter->rtw_wdev->wiphy, notify_channel,
 			pnetwork->MacAddress, pnetwork->Ssid.Ssid,
 			pnetwork->Ssid.SsidLength,
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0)
-			pnetwork->InfrastructureMode == Ndis802_11Infrastructure?IEEE80211_BSS_TYPE_ESS:IEEE80211_BSS_TYPE_IBSS,
-			IEEE80211_PRIVACY(pnetwork->Privacy));
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0))
+			pnetwork->InfrastructureMode == Ndis802_11Infrastructure ? IEEE80211_BSS_TYPE_ESS : IEEE80211_BSS_TYPE_IBSS,
+			IEEE80211_PRIVACY(pnetwork->Privacy)
 #else
-			pnetwork->InfrastructureMode == Ndis802_11Infrastructure?WLAN_CAPABILITY_ESS:WLAN_CAPABILITY_IBSS, pnetwork->InfrastructureMode == Ndis802_11Infrastructure?WLAN_CAPABILITY_ESS:WLAN_CAPABILITY_IBSS);
+			pnetwork->InfrastructureMode == Ndis802_11Infrastructure ? WLAN_CAPABILITY_ESS : WLAN_CAPABILITY_IBSS,
+			pnetwork->InfrastructureMode == Ndis802_11Infrastructure ? WLAN_CAPABILITY_ESS : WLAN_CAPABILITY_IBSS
 #endif
+	);
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 9, 0)
-	cfg80211_put_bss(padapter->rtw_wdev->wiphy, bss);
-#else
-	cfg80211_put_bss(bss);
+	cfg80211_put_bss(
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 9, 0))
+		padapter->rtw_wdev->wiphy,
 #endif
+		bss
+	);
 
 	return bss != NULL;
 }
@@ -1008,7 +1012,7 @@ void rtw_cfg80211_indicate_connect(_adapter *padapter)
 #ifdef CONFIG_P2P
 	struct wifidirect_info *pwdinfo = &(padapter->wdinfo);
 #endif
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0))
 	struct cfg80211_roam_info roam_info ={};
 #endif
 
@@ -1071,7 +1075,7 @@ check_bss:
 	_enter_critical_bh(&pwdev_priv->connect_req_lock, &irqL);
 
 	if (rtw_to_roam(padapter) > 0) {
-		#if LINUX_VERSION_CODE > KERNEL_VERSION(2, 6, 39) || defined(COMPAT_KERNEL_RELEASE)
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(2, 6, 39)) || defined(COMPAT_KERNEL_RELEASE)
 		struct wiphy *wiphy = pwdev->wiphy;
 		struct ieee80211_channel *notify_channel;
 		u32 freq;
@@ -1079,34 +1083,34 @@ check_bss:
 
 		freq = rtw_ch2freq(channel);
 		notify_channel = ieee80211_get_channel(wiphy, freq);
-		#endif
+#endif
 
-		#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0)
-		#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 0, 0)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0))
+	#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 0, 0))
 		roam_info.channel = notify_channel;
 		roam_info.bssid = cur_network->network.MacAddress;
-		#else
+	#else
 		roam_info.links[0].channel = notify_channel;
 		roam_info.links[0].bssid = cur_network->network.MacAddress;
-		#endif
+	#endif
 		roam_info.req_ie = pmlmepriv->assoc_req + sizeof(struct rtw_ieee80211_hdr_3addr) + 2;
 		roam_info.req_ie_len = pmlmepriv->assoc_req_len - sizeof(struct rtw_ieee80211_hdr_3addr) - 2;
 		roam_info.resp_ie = pmlmepriv->assoc_rsp + sizeof(struct rtw_ieee80211_hdr_3addr) + 6;
 		roam_info.resp_ie_len = pmlmepriv->assoc_rsp_len - sizeof(struct rtw_ieee80211_hdr_3addr) - 6;
 
 		cfg80211_roamed(padapter->pnetdev, &roam_info, GFP_ATOMIC);
-		#else
+#else
 		cfg80211_roamed(padapter->pnetdev
-			#if LINUX_VERSION_CODE > KERNEL_VERSION(2, 6, 39) || defined(COMPAT_KERNEL_RELEASE)
+	#if (LINUX_VERSION_CODE > KERNEL_VERSION(2, 6, 39)) || defined(COMPAT_KERNEL_RELEASE)
 			, notify_channel
-			#endif
+	#endif
 			, cur_network->network.MacAddress
 			, pmlmepriv->assoc_req + sizeof(struct rtw_ieee80211_hdr_3addr) + 2
 			, pmlmepriv->assoc_req_len - sizeof(struct rtw_ieee80211_hdr_3addr) - 2
 			, pmlmepriv->assoc_rsp + sizeof(struct rtw_ieee80211_hdr_3addr) + 6
 			, pmlmepriv->assoc_rsp_len - sizeof(struct rtw_ieee80211_hdr_3addr) - 6
 			, GFP_ATOMIC);
-		#endif /*LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0)*/
+#endif /*LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0)*/
 
 		RTW_INFO(FUNC_ADPT_FMT" call cfg80211_roamed\n", FUNC_ADPT_ARG(padapter));
 
@@ -1115,9 +1119,9 @@ check_bss:
 			rtw_ft_set_status(padapter, RTW_FT_ASSOCIATED_STA);
 #endif
 	} else {
-		#if LINUX_VERSION_CODE < KERNEL_VERSION(3, 11, 0) || defined(COMPAT_KERNEL_RELEASE)
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 11, 0)) || defined(COMPAT_KERNEL_RELEASE)
 		RTW_INFO("pwdev->sme_state(b)=%d\n", pwdev->sme_state);
-		#endif
+#endif
 
 		if (check_fwstate(pmlmepriv, WIFI_MONITOR_STATE) != _TRUE)
 			rtw_cfg80211_connect_result(pwdev, cur_network->network.MacAddress
@@ -1126,9 +1130,9 @@ check_bss:
 				, pmlmepriv->assoc_rsp + sizeof(struct rtw_ieee80211_hdr_3addr) + 6
 				, pmlmepriv->assoc_rsp_len - sizeof(struct rtw_ieee80211_hdr_3addr) - 6
 				, WLAN_STATUS_SUCCESS, GFP_ATOMIC);
-		#if LINUX_VERSION_CODE < KERNEL_VERSION(3, 11, 0) || defined(COMPAT_KERNEL_RELEASE)
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 11, 0)) || defined(COMPAT_KERNEL_RELEASE)
 		RTW_INFO("pwdev->sme_state(a)=%d\n", pwdev->sme_state);
-		#endif
+#endif
 	}
 
 	rtw_wdev_free_connect_req(pwdev_priv);
@@ -1166,11 +1170,11 @@ void rtw_cfg80211_indicate_disconnect(_adapter *padapter, u16 reason, u8 locally
 		if (!rtw_p2p_chk_state(pwdinfo, P2P_STATE_NONE)) {
 			rtw_p2p_set_state(pwdinfo, rtw_p2p_pre_state(pwdinfo));
 
-			#if RTW_P2P_GROUP_INTERFACE
-			#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37)) || defined(COMPAT_KERNEL_RELEASE)
+	#if RTW_P2P_GROUP_INTERFACE
+		#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37)) || defined(COMPAT_KERNEL_RELEASE)
 			if (pwdev->iftype != NL80211_IFTYPE_P2P_CLIENT)
-			#endif
-			#endif
+		#endif
+	#endif
 				rtw_p2p_set_role(pwdinfo, P2P_ROLE_DEVICE);
 
 			RTW_INFO("%s, role=%d, p2p_state=%d, pre_p2p_state=%d\n", __func__, rtw_p2p_role(pwdinfo), rtw_p2p_state(pwdinfo), rtw_p2p_pre_state(pwdinfo));
@@ -1181,7 +1185,7 @@ void rtw_cfg80211_indicate_disconnect(_adapter *padapter, u16 reason, u8 locally
 	_enter_critical_bh(&pwdev_priv->connect_req_lock, &irqL);
 
 	if (padapter->ndev_unregistering || !rtw_wdev_not_indic_disco(pwdev_priv)) {
-		#if LINUX_VERSION_CODE < KERNEL_VERSION(3, 11, 0) || defined(COMPAT_KERNEL_RELEASE)
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 11, 0)) || defined(COMPAT_KERNEL_RELEASE)
 		RTW_INFO("pwdev->sme_state(b)=%d\n", pwdev->sme_state);
 
 		if (pwdev->sme_state == CFG80211_SME_CONNECTING) {
@@ -1194,7 +1198,7 @@ void rtw_cfg80211_indicate_disconnect(_adapter *padapter, u16 reason, u8 locally
 		}
 
 		RTW_INFO("pwdev->sme_state(a)=%d\n", pwdev->sme_state);
-		#else
+#else
 		if (pwdev_priv->connect_req) {
 			RTW_INFO(FUNC_ADPT_FMT" call cfg80211_connect_result\n", FUNC_ADPT_ARG(padapter));
 			rtw_cfg80211_connect_result(pwdev, NULL, NULL, 0, NULL, 0,
@@ -1203,7 +1207,7 @@ void rtw_cfg80211_indicate_disconnect(_adapter *padapter, u16 reason, u8 locally
 			RTW_INFO(FUNC_ADPT_FMT" call cfg80211_disconnected\n", FUNC_ADPT_ARG(padapter));
 			rtw_cfg80211_disconnected(pwdev, reason, NULL, 0, locally_generated, GFP_ATOMIC);
 		}
-		#endif
+#endif
 	}
 
 	rtw_wdev_free_connect_req(pwdev_priv);
@@ -2464,7 +2468,7 @@ void rtw_cfg80211_indicate_scan_done(_adapter *adapter, bool aborted)
 	struct rtw_wdev_priv *pwdev_priv = adapter_wdev_data(adapter);
 	_irqL	irqL;
 
-#if (KERNEL_VERSION(4, 7, 0) <= LINUX_VERSION_CODE)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 7, 0))
 	struct cfg80211_scan_info info;
 
 	memset(&info, 0, sizeof(info));
@@ -2481,7 +2485,7 @@ void rtw_cfg80211_indicate_scan_done(_adapter *adapter, bool aborted)
 		if (pwdev_priv->scan_request->wiphy != pwdev_priv->rtw_wdev->wiphy)
 			RTW_INFO("error wiphy compare\n");
 		else
-#if (KERNEL_VERSION(4, 7, 0) <= LINUX_VERSION_CODE)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 7, 0))
 			cfg80211_scan_done(pwdev_priv->scan_request, &info);
 #else
 			cfg80211_scan_done(pwdev_priv->scan_request, aborted);
@@ -2537,22 +2541,24 @@ void rtw_cfg80211_unlink_bss(_adapter *padapter, struct wlan_network *pnetwork)
 	bss = cfg80211_get_bss(wiphy, NULL/*notify_channel*/,
 		select_network.MacAddress, select_network.Ssid.Ssid,
 		select_network.Ssid.SsidLength,
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0)
-		select_network.InfrastructureMode == Ndis802_11Infrastructure?IEEE80211_BSS_TYPE_ESS:IEEE80211_BSS_TYPE_IBSS,
-		IEEE80211_PRIVACY(select_network.Privacy));
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0))
+		select_network.InfrastructureMode == Ndis802_11Infrastructure ? IEEE80211_BSS_TYPE_ESS : IEEE80211_BSS_TYPE_IBSS,
+		IEEE80211_PRIVACY(select_network.Privacy)
 #else
-		select_network.InfrastructureMode == Ndis802_11Infrastructure?WLAN_CAPABILITY_ESS:WLAN_CAPABILITY_IBSS,
-		select_network.InfrastructureMode == Ndis802_11Infrastructure?WLAN_CAPABILITY_ESS:WLAN_CAPABILITY_IBSS);
+		select_network.InfrastructureMode == Ndis802_11Infrastructure ? WLAN_CAPABILITY_ESS:WLAN_CAPABILITY_IBSS,
+		select_network.InfrastructureMode == Ndis802_11Infrastructure ? WLAN_CAPABILITY_ESS:WLAN_CAPABILITY_IBSS
 #endif
+	);
 
 	if (bss) {
 		cfg80211_unlink_bss(wiphy, bss);
 		RTW_INFO("%s(): cfg80211_unlink %s!!\n", __func__, select_network.Ssid.Ssid);
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 9, 0)
-		cfg80211_put_bss(padapter->rtw_wdev->wiphy, bss);
-#else
-		cfg80211_put_bss(bss);
+		cfg80211_put_bss(
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 9, 0))
+			padapter->rtw_wdev->wiphy,
 #endif
+			bss
+		);
 	}
 	return;
 }
@@ -3182,7 +3188,7 @@ bypass_p2p_chk:
 
 check_need_indicate_scan_done:
 	if (_TRUE == need_indicate_scan_done) {
-#if (KERNEL_VERSION(4, 7, 0) <= LINUX_VERSION_CODE)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 7, 0))
 		struct cfg80211_scan_info info;
 
 		memset(&info, 0, sizeof(info));
@@ -3190,7 +3196,7 @@ check_need_indicate_scan_done:
 #endif
 
 		_rtw_cfg80211_surveydone_event_callback(padapter, request);
-#if (KERNEL_VERSION(4, 7, 0) <= LINUX_VERSION_CODE)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 7, 0))
 		cfg80211_scan_done(request, &info);
 #else
 		cfg80211_scan_done(request, 0);
@@ -4985,12 +4991,12 @@ static int cfg80211_rtw_change_beacon(struct wiphy *wiphy, struct net_device *nd
 	return ret;
 }
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 2)
-static int cfg80211_rtw_stop_ap(struct wiphy *wiphy, struct net_device *ndev)
-#else
-static int cfg80211_rtw_stop_ap(struct wiphy *wiphy, struct net_device *ndev, unsigned int link_id)
+static int cfg80211_rtw_stop_ap(
+	struct wiphy *wiphy, struct net_device *ndev
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 19, 2))
+	, unsigned int link_id
 #endif
-{
+) {
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(ndev);
 
 	RTW_INFO(FUNC_NDEV_FMT"\n", FUNC_NDEV_ARG(ndev));
@@ -8602,9 +8608,9 @@ static int cfg80211_rtw_sched_scan_start(struct wiphy *wiphy,
 		RTW_INFO("%s: invalid cfg80211_requests parameters.\n", __func__);
 		return -EINVAL;
 	}
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 2, 0)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 2, 0))
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0))
 	interval = request->scan_plans->interval;
 #else
 	interval = request->interval;
@@ -8625,7 +8631,7 @@ static int cfg80211_rtw_sched_scan_start(struct wiphy *wiphy,
 	n_ssids = request->n_ssids;
 	ssids = request->ssids;
 #endif
-ret = rtw_android_cfg80211_pno_setup(dev, ssids,
+	ret = rtw_android_cfg80211_pno_setup(dev, ssids,
 			n_ssids, interval);
 	if (ret < 0) {
 		RTW_INFO("%s ret: %d\n", __func__, ret);
@@ -9376,7 +9382,7 @@ static void rtw_cfg80211_preinit_wiphy(_adapter *adapter, struct wiphy *wiphy)
 	wiphy->flags |= WIPHY_FLAG_SUPPORTS_SCHED_SCAN;
 #ifdef CONFIG_PNO_SUPPORT
 	wiphy->max_sched_scan_ssids = MAX_PNO_LIST_COUNT;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 2, 0)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 2, 0))
 	wiphy->max_match_sets = MAX_PNO_LIST_COUNT;
 #endif
 #endif
@@ -9904,7 +9910,7 @@ void rtw_wdev_unregister(struct wireless_dev *wdev)
 	rtw_cfg80211_indicate_scan_done(adapter, _TRUE);
 
 	#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 11, 0)) || defined(COMPAT_KERNEL_RELEASE)
-	#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 2)
+	#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 2))
 	if (wdev->current_bss) {
 	#else
 	if (wdev->connected) {

--- a/os_dep/linux/ioctl_linux.c
+++ b/os_dep/linux/ioctl_linux.c
@@ -9787,7 +9787,7 @@ static int rtw_mp_efuse_set(struct net_device *dev,
 		/* set mac addr*/
 		rtw_macaddr_cfg(adapter_mac_addr(padapter), get_hal_mac_addr(padapter));
 
-		#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0)
+		#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0))
 		_rtw_memcpy(padapter->pnetdev->dev_addr, get_hal_mac_addr(padapter), ETH_ALEN); /* set mac addr to net_device */
 		#else
 		eth_hw_addr_set(padapter->pnetdev, get_hal_mac_addr(padapter));

--- a/os_dep/linux/mlme_linux.c
+++ b/os_dep/linux/mlme_linux.c
@@ -400,11 +400,11 @@ int hostapd_mode_init(_adapter *padapter)
 	mac[4] = 0x11;
 	mac[5] = 0x12;
 
-  #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0)
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0))
 	_rtw_memcpy(pnetdev->dev_addr, mac, ETH_ALEN);
-	#else
-  eth_hw_addr_set(pnetdev, mac);
-  #endif
+#else
+	eth_hw_addr_set(pnetdev, mac);
+#endif
 
 
 	rtw_netif_carrier_off(pnetdev);

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -1241,11 +1241,11 @@ static int rtw_net_set_mac_address(struct net_device *pnetdev, void *addr)
 	}
 
 	_rtw_memcpy(adapter_mac_addr(padapter), sa->sa_data, ETH_ALEN); /* set mac addr to adapter */
-	#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0)
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0))
 	_rtw_memcpy(pnetdev->dev_addr, sa->sa_data, ETH_ALEN); /* set mac addr to net_device */
-	#else
-  eth_hw_addr_set(pnetdev, sa->sa_data);
-  #endif
+#else
+	eth_hw_addr_set(pnetdev, sa->sa_data);
+#endif
 
 #if 0
 	if (rtw_is_hw_init_completed(padapter)) {
@@ -1342,9 +1342,9 @@ static u16 rtw_select_queue(struct net_device *dev, struct sk_buff *skb
 )
 #else
 static u16 rtw_select_queue(struct net_device *dev, struct sk_buff *skb
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0))
 	, void *accel_priv
-	#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)
+	#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0))
 	, select_queue_fallback_t fallback
 	#endif
 #endif
@@ -1576,7 +1576,7 @@ struct net_device *rtw_init_netdev(_adapter *old_padapter)
 	padapter = rtw_netdev_priv(pnetdev);
 	padapter->pnetdev = pnetdev;
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 24)
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 24))
 	SET_MODULE_OWNER(pnetdev);
 #endif
 
@@ -1586,24 +1586,23 @@ struct net_device *rtw_init_netdev(_adapter *old_padapter)
 		rtw_hook_vir_if_ops(pnetdev);
 #endif /* CONFIG_CONCURRENT_MODE */
 
-
 #ifdef CONFIG_TX_CSUM_OFFLOAD
-        pnetdev->features |= (NETIF_F_IP_CSUM | NETIF_F_IPV6_CSUM);
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 39)
-        pnetdev->hw_features |= (NETIF_F_IP_CSUM | NETIF_F_IPV6_CSUM);
+    pnetdev->features |= (NETIF_F_IP_CSUM | NETIF_F_IPV6_CSUM);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 39)_
+    pnetdev->hw_features |= (NETIF_F_IP_CSUM | NETIF_F_IPV6_CSUM);
 #endif
 #endif
 
 #ifdef CONFIG_RTW_NETIF_SG
-        pnetdev->features |= NETIF_F_SG;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 39)
-        pnetdev->hw_features |= NETIF_F_SG;
+    pnetdev->features |= NETIF_F_SG;
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 39))
+    pnetdev->hw_features |= NETIF_F_SG;
 #endif
 #endif
 
 	if ((pnetdev->features & NETIF_F_SG) && (pnetdev->features & NETIF_F_IP_CSUM)) {
 		pnetdev->features |= (NETIF_F_TSO | NETIF_F_GSO);
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 39)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 39))
 		pnetdev->hw_features |= (NETIF_F_TSO | NETIF_F_GSO);
 #endif
 	}
@@ -1632,7 +1631,7 @@ int rtw_os_ndev_alloc(_adapter *adapter)
 		rtw_warn_on(1);
 		goto exit;
 	}
-#if LINUX_VERSION_CODE > KERNEL_VERSION(2, 5, 0)
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(2, 5, 0))
 	SET_NETDEV_DEV(ndev, dvobj_to_dev(adapter_to_dvobj(adapter)));
 #endif
 
@@ -1707,11 +1706,11 @@ int rtw_os_ndev_register(_adapter *adapter, const char *name)
 	/* alloc netdev name */
 	rtw_init_netdev_name(ndev, name);
 
-	#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0)
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0))
 	_rtw_memcpy(ndev->dev_addr, adapter_mac_addr(adapter), ETH_ALEN);
-	#else
-  eth_hw_addr_set(ndev, adapter_mac_addr(adapter));
-  #endif
+#else
+	eth_hw_addr_set(ndev, adapter_mac_addr(adapter));
+#endif
 
 	/* Tell the network stack we exist */
 
@@ -2679,7 +2678,7 @@ int _netdev_vir_if_open(struct net_device *pnetdev)
 		rtw_mbid_camid_alloc(padapter, adapter_mac_addr(padapter));
 #endif
 		rtw_init_wifidirect_addrs(padapter, adapter_mac_addr(padapter), adapter_mac_addr(padapter));
-		#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0)
+		#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0))
 		_rtw_memcpy(pnetdev->dev_addr, adapter_mac_addr(padapter), ETH_ALEN);
 		#else
 		eth_hw_addr_set(pnetdev, adapter_mac_addr(padapter));
@@ -3432,7 +3431,7 @@ int _netdev_open(struct net_device *pnetdev)
 		rtw_mbid_camid_alloc(padapter, adapter_mac_addr(padapter));
 #endif
 		rtw_init_wifidirect_addrs(padapter, adapter_mac_addr(padapter), adapter_mac_addr(padapter));
-		#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0)
+		#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0))
 		_rtw_memcpy(pnetdev->dev_addr, adapter_mac_addr(padapter), ETH_ALEN);
 		#else
 		eth_hw_addr_set(pnetdev, adapter_mac_addr(padapter));

--- a/os_dep/linux/rtw_android.c
+++ b/os_dep/linux/rtw_android.c
@@ -306,7 +306,7 @@ int rtw_android_cfg80211_pno_setup(struct net_device *net,
 		memcpy(pno_ssids_local[index].SSID, ssids[index].ssid,
 		       ssids[index].ssid_len);
 	}
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 2, 0)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 2, 0))
 	if(ssids)
 		rtw_mfree((u8 *)ssids, (n_ssids * sizeof(struct cfg80211_ssid)));
 #endif

--- a/os_dep/linux/rtw_cfgvendor.c
+++ b/os_dep/linux/rtw_cfgvendor.c
@@ -1748,7 +1748,7 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
 			.subcmd = GSCAN_SUBCMD_GET_CAPABILITIES
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0))
 		.policy = VENDOR_CMD_RAW_DATA,
 #endif
 		.doit = rtw_cfgvendor_gscan_get_capabilities
@@ -1759,7 +1759,7 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
 			.subcmd = GSCAN_SUBCMD_SET_CONFIG
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0))
 		.policy = VENDOR_CMD_RAW_DATA,
 #endif
 		.doit = rtw_cfgvendor_set_scan_cfg
@@ -1770,7 +1770,7 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
 			.subcmd = GSCAN_SUBCMD_SET_SCAN_CONFIG
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0))
 		.policy = VENDOR_CMD_RAW_DATA,
 #endif
 		.doit = rtw_cfgvendor_set_batch_scan_cfg
@@ -1781,7 +1781,7 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
 			.subcmd = GSCAN_SUBCMD_ENABLE_GSCAN
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0))
 		.policy = VENDOR_CMD_RAW_DATA,
 #endif
 		.doit = rtw_cfgvendor_initiate_gscan
@@ -1792,7 +1792,7 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
 			.subcmd = GSCAN_SUBCMD_ENABLE_FULL_SCAN_RESULTS
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0))
 		.policy = VENDOR_CMD_RAW_DATA,
 #endif
 		.doit = rtw_cfgvendor_enable_full_scan_result
@@ -1803,7 +1803,7 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
 			.subcmd = GSCAN_SUBCMD_SET_HOTLIST
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0))
 		.policy = VENDOR_CMD_RAW_DATA,
 #endif
 		.doit = rtw_cfgvendor_hotlist_cfg
@@ -1814,7 +1814,7 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
 			.subcmd = GSCAN_SUBCMD_SET_SIGNIFICANT_CHANGE_CONFIG
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0))
 		.policy = VENDOR_CMD_RAW_DATA,
 #endif
 		.doit = rtw_cfgvendor_significant_change_cfg
@@ -1825,7 +1825,7 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
 			.subcmd = GSCAN_SUBCMD_GET_SCAN_RESULTS
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0))
 		.policy = VENDOR_CMD_RAW_DATA,
 #endif
 		.doit = rtw_cfgvendor_gscan_get_batch_results
@@ -1836,7 +1836,7 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
 			.subcmd = GSCAN_SUBCMD_GET_CHANNEL_LIST
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0))
 		.policy = VENDOR_CMD_RAW_DATA,
 #endif
 		.doit = rtw_cfgvendor_gscan_get_channel_list
@@ -1849,7 +1849,7 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
 			.subcmd = RTT_SUBCMD_SET_CONFIG
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0))
 		.policy = VENDOR_CMD_RAW_DATA,
 #endif
 		.doit = rtw_cfgvendor_rtt_set_config
@@ -1860,7 +1860,7 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
 			.subcmd = RTT_SUBCMD_CANCEL_CONFIG
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0))
 		.policy = VENDOR_CMD_RAW_DATA,
 #endif
 		.doit = rtw_cfgvendor_rtt_cancel_config
@@ -1871,7 +1871,7 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
 			.subcmd = RTT_SUBCMD_GETCAPABILITY
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0))
 		.policy = VENDOR_CMD_RAW_DATA,
 #endif
 		.doit = rtw_cfgvendor_rtt_get_capability
@@ -1884,7 +1884,7 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
 			.subcmd = LSTATS_SUBCMD_GET_INFO
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0))
 		.policy = VENDOR_CMD_RAW_DATA,
 #endif
 		.doit = rtw_cfgvendor_lstats_get_info
@@ -1895,7 +1895,7 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
 			.subcmd = LSTATS_SUBCMD_SET_INFO
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0))
 		.policy = VENDOR_CMD_RAW_DATA,
 #endif
 		.doit = rtw_cfgvendor_lstats_set_info
@@ -1906,7 +1906,7 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
 			.subcmd = LSTATS_SUBCMD_CLEAR_INFO
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0))
 		.policy = VENDOR_CMD_RAW_DATA,
 #endif
 		.doit = rtw_cfgvendor_lstats_clear_info
@@ -1919,7 +1919,7 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
                         .subcmd = WIFI_SUBCMD_SET_RSSI_MONITOR
                 },
                 .flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0))
 		.policy = VENDOR_CMD_RAW_DATA,
 #endif
                 .doit = rtw_cfgvendor_set_rssi_monitor
@@ -1932,7 +1932,7 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
 			.subcmd = LOGGER_START_LOGGING
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0))
 		.policy = VENDOR_CMD_RAW_DATA,
 #endif
 		.doit = rtw_cfgvendor_logger_start_logging
@@ -1943,7 +1943,7 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
 			.subcmd = LOGGER_GET_FEATURE
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0))
 		.policy = VENDOR_CMD_RAW_DATA,
 #endif
 		.doit = rtw_cfgvendor_logger_get_feature
@@ -1954,7 +1954,7 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
 			.subcmd = LOGGER_GET_VER
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0))
 		.policy = VENDOR_CMD_RAW_DATA,
 #endif
 		.doit = rtw_cfgvendor_logger_get_version
@@ -1965,7 +1965,7 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
 			.subcmd = LOGGER_GET_RING_STATUS
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0))
 		.policy = VENDOR_CMD_RAW_DATA,
 #endif
 		.doit = rtw_cfgvendor_logger_get_ring_status
@@ -1976,7 +1976,7 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
 			.subcmd = LOGGER_GET_RING_DATA
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0))
 		.policy = VENDOR_CMD_RAW_DATA,
 #endif
 		.doit = rtw_cfgvendor_logger_get_ring_data
@@ -1987,7 +1987,7 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
 			.subcmd = LOGGER_TRIGGER_MEM_DUMP
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0))
 		.policy = VENDOR_CMD_RAW_DATA,
 #endif
 		.doit = rtw_cfgvendor_logger_get_firmware_memory_dump
@@ -1998,7 +1998,7 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
 			.subcmd = LOGGER_START_PKT_FATE_MONITORING
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0))
 		.policy = VENDOR_CMD_RAW_DATA,
 #endif
 		.doit = rtw_cfgvendor_logger_start_pkt_fate_monitoring
@@ -2009,7 +2009,7 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
 			.subcmd = LOGGER_GET_TX_PKT_FATES
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0))
 		.policy = VENDOR_CMD_RAW_DATA,
 #endif
 		.doit = rtw_cfgvendor_logger_get_tx_pkt_fates
@@ -2020,7 +2020,7 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
 			.subcmd = LOGGER_GET_RX_PKT_FATES
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0))
 		.policy = VENDOR_CMD_RAW_DATA,
 #endif
 		.doit = rtw_cfgvendor_logger_get_rx_pkt_fates
@@ -2034,7 +2034,7 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
 			.subcmd = WIFI_SUBCMD_SET_PNO_RANDOM_MAC_OUI
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0))
 		.policy = VENDOR_CMD_RAW_DATA,
 #endif
 		.doit = rtw_cfgvendor_set_rand_mac_oui
@@ -2046,7 +2046,7 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
 			.subcmd = WIFI_SUBCMD_NODFS_SET
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0))
 		.policy = VENDOR_CMD_RAW_DATA,
 #endif
 		.doit = rtw_cfgvendor_set_nodfs_flag
@@ -2057,7 +2057,7 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
 			.subcmd = WIFI_SUBCMD_SET_COUNTRY_CODE
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0))
 		.policy = VENDOR_CMD_RAW_DATA,
 #endif
 		.doit = rtw_cfgvendor_set_country
@@ -2068,7 +2068,7 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
 			.subcmd = WIFI_SUBCMD_CONFIG_ND_OFFLOAD
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0))
 		.policy = VENDOR_CMD_RAW_DATA,
 #endif
 		.doit = rtw_cfgvendor_set_nd_offload
@@ -2080,7 +2080,7 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
 			.subcmd = WIFI_SUBCMD_GET_FEATURE_SET
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0))
 		.policy = VENDOR_CMD_RAW_DATA,
 #endif
 		.doit = rtw_cfgvendor_get_feature_set
@@ -2091,7 +2091,7 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
 			.subcmd = WIFI_SUBCMD_GET_FEATURE_SET_MATRIX
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0))
 		.policy = VENDOR_CMD_RAW_DATA,
 #endif
 		.doit = rtw_cfgvendor_get_feature_set_matrix

--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -2513,11 +2513,11 @@ int rtw_change_ifname(_adapter *padapter, const char *ifname)
 
 	rtw_init_netdev_name(pnetdev, ifname);
 
-	#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0)
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0))
 	_rtw_memcpy(pnetdev->dev_addr, adapter_mac_addr(padapter), ETH_ALEN);
-	#else
-  eth_hw_addr_set(pnetdev, adapter_mac_addr(padapter));
-  #endif
+#else
+	eth_hw_addr_set(pnetdev, adapter_mac_addr(padapter));
+#endif
 
 	if (rtnl_lock_needed)
 		ret = register_netdev(pnetdev);


### PR DESCRIPTION
It should ensure that on earlier kernel version, proper code is generated across whole driver.

For 6.13 it generate extacly the same code like before changes.
Except that its a little more readable